### PR TITLE
Fix bug from passing BigNumber to contract call

### DIFF
--- a/src/Fund.js
+++ b/src/Fund.js
@@ -25,7 +25,7 @@ class Fund extends Component {
 
     handleSubmit(evt) {
         evt.preventDefault();
-        this.props.funding(new BigNumber(this.state.funding).shiftedBy(18));
+        this.props.funding(new BigNumber(this.state.funding).shiftedBy(18).toString());
         this.setState({funding: ""})
     }
 

--- a/src/Withdraw.js
+++ b/src/Withdraw.js
@@ -23,7 +23,7 @@ class Withdraw extends Component {
 
     handleSubmit(evt) {
         evt.preventDefault();
-        this.props.withdraw(new BigNumber(this.state.withdraw).shiftedBy(18));
+        this.props.withdraw(new BigNumber(this.state.withdraw).shiftedBy(18).toString());
         this.setState({withdraw: ""})
     }
 


### PR DESCRIPTION
Submitting funding or withdrawal requests were failing with:
```
index.ts:225 Uncaught (in promise) Error: invalid BigNumber value (argument="value", value="3000000000000000000", code=INVALID_ARGUMENT, version=bignumber/5.4.1)
    at e.value (index.ts:225:28)
    at e.value (index.ts:237:20)
    at e.value (index.ts:241:21)
    at Function.value (bignumber.ts:291:23)
    at n.value (number.ts:21:27)
    at array.ts:71:19
    at Array.forEach (<anonymous>)
    at K (array.ts:54:12)
    at n.value (tuple.ts:23:16)
    at e.value (abi-coder.ts:106:15)
```

I'll admit I still get transaction errors but at least they are submitting! (I'm mostly just looking at the code as a reference implementation so it's not bothering me that the transactions fail - thanks again for the demo repo)